### PR TITLE
Add geometryType to metadata and allow option to cache if configured.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+* Add `metadata.geometryType` to translated GeoJSON
+* Add caching if `ttl` found in the config
+
 ## [1.1.0] - 2018-02-26
 ### Added
 * Default geometry translations for point data

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The S3 Select provider uses the [config](http://lorenwest.github.io/node-config/
 {
   "koopProviderS3Select": {
     "s3Path": "my-default-bucket", // default path
+    "ttl": 300, // The TTL option is measured in seconds, it will be used to set the cache expiration entry
     "stores": {
       "my-store-key": {
         "s3Path": "my-other-bucket/a-folder", // specific path for this store
@@ -46,6 +47,7 @@ The S3 Select provider uses the [config](http://lorenwest.github.io/node-config/
 | key | type | description | required |
 | -- | -- | -- | -- |
 | `s3Path` | String | Default path-prefix that will be prepended to all requested files. Begins with the S3 bucket name and may include any sub-directory path. | No |
+| `ttl` | Integer | Number of seconds to cache the data | No |
 | `stores` | Object |key-value lookup used by the provider to fetch specific configuration information for a request. Each key in `stores` defines a valid value of the `:host` route parameter | Yes |
 | `stores[<key>].s3Path`| String | Path-prefix that will be prepended to all file requests when `:host` is equal to `<key>` | No |
 | `stores[<key>].serialization`| Object | S3 input serialization object. Informs S3 how files requested with a give `:host` value should be deserialized. See [S3 documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectSELECTContent.html).| No |

--- a/lib/translate.js
+++ b/lib/translate.js
@@ -1,3 +1,4 @@
+const _ = require('lodash')
 const { isFeatureArray, isFeatureCollection, isFeatureGeometryArray, isObjectArray } = require('./match-schema')
 const { fetchPointGeometry, fetchPointGeometryKeys } = require('./fetch-point-geometry')
 /**
@@ -9,14 +10,18 @@ const { fetchPointGeometry, fetchPointGeometryKeys } = require('./fetch-point-ge
 function translate (json) {
   if (!Array.isArray(json)) throw new Error('Expected JSON array.')
 
-  // Match input JSON to a specified schema, then translate to GeoJSON feature collection
-  if (isFeatureCollection(json)) return json[0]
-  if (isFeatureArray(json)) return translateFeatureArray(json)
-  if (isFeatureGeometryArray(json)) return translateFeatureGeometryArray(json)
-  if (isObjectArray(json)) return translateObjectArray(json)
+  let geojson
 
-  // If here, the input json is an array of strings or primatives
-  throw new Error('S3 file contents cannot be translated to GeoJSON.')
+  // Match input JSON to a specified schema, then translate to GeoJSON feature collection
+  if (isFeatureCollection(json)) geojson = json[0]
+  else if (isFeatureArray(json)) geojson = translateFeatureArray(json)
+  else if (isFeatureGeometryArray(json)) geojson = translateFeatureGeometryArray(json)
+  else if (isObjectArray(json)) geojson = translateObjectArray(json)
+  else throw new Error('S3 file contents cannot be translated to GeoJSON.') // If here, the input json is an array of strings or primatives
+
+  geojson.metadata = { }
+  geojson.metadata.geometryType = _.get(geojson, 'features[0].geometry.type')
+  return geojson
 }
 
 /**

--- a/model.js
+++ b/model.js
@@ -56,6 +56,9 @@ Model.prototype.getData = async function (req, callback) {
     const json = await select(params)
     const geojson = translate(json)
 
+    // Turn on cache if ttl found in configuration
+    if (config.koopProviderS3Select.ttl) geojson.ttl = config.koopProviderS3Select.ttl
+
     // TODO: Once query parameters are used in SQL select, add metadata annotations
     // so output-services don't duplicate post-processing; e.g., geojson.metadata.filtersApplied.where
     return callback(null, geojson)

--- a/test/translate.spec.js
+++ b/test/translate.spec.js
@@ -17,6 +17,9 @@ const featureCollectionArrFixture = require('./fixtures/feature-collection-array
 // Schema for a GeoJSON feature collection
 const schemaFeatureCollection = Joi.object().keys({
   type: Joi.string().required().valid('FeatureCollection').optional(),
+  metadata: Joi.object().keys({
+    geometryType: Joi.string().optional()
+  }),
   features: Joi.array().items(Joi.object().keys({
     type: Joi.string().valid('Feature'),
     properties: Joi.object().required(),


### PR DESCRIPTION
- Add a `geometryType` to the model's geojson.
- Add option to use caching if `ttl` is set in configuration.